### PR TITLE
Update pause-on-lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ Simple script that pauses your music player, when the screen gets locked and
 resumes playback once the screen is unlocked again.
 
 ### Supported desktop environments
-Currently [Unity](https://launchpad.net/unity), [Cinnamon](https://github.com/linuxmint/Cinnamon)
-and [GNOME](https://www.gnome.org/) are supported. The currently running
+Currently [Unity](https://launchpad.net/unity), [Cinnamon](https://github.com/linuxmint/Cinnamon), [GNOME](https://www.gnome.org/) and [MATE](https://mate-desktop.org/) are supported. The currently running
 desktop is detected using `$XDG_CURRENT_DESKTOP`.
 
 ### Supported players

--- a/pause-on-lock
+++ b/pause-on-lock
@@ -30,11 +30,11 @@ elif [[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]] ; then
   LOCK_SIGNAL="true"
   UNLOCK_SIGNAL="false"
 elif [ "$XDG_CURRENT_DESKTOP" == "X-Cinnamon" ] ; then
-  DBUS_LOCK="interface='org.mate.ScreenSaver',member='ActiveChanged'"
+  DBUS_LOCK="interface='org.x-cinnamon.ScreenSaver',member='ActiveChanged'"
   LOCK_SIGNAL="true"
   UNLOCK_SIGNAL="false"
 elif [ "$XDG_CURRENT_DESKTOP" == "MATE" ] ; then
-  DBUS_LOCK="interface='org.cinnamon.ScreenSaver',member='ActiveChanged'"
+  DBUS_LOCK="interface='org.mate.ScreenSaver',member='ActiveChanged'"
   LOCK_SIGNAL="true"
   UNLOCK_SIGNAL="false"
 else

--- a/pause-on-lock
+++ b/pause-on-lock
@@ -30,7 +30,7 @@ elif [[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]] ; then
   LOCK_SIGNAL="true"
   UNLOCK_SIGNAL="false"
 elif [ "$XDG_CURRENT_DESKTOP" == "X-Cinnamon" ] ; then
-  DBUS_LOCK="interface='org.x-cinnamon.ScreenSaver',member='ActiveChanged'"
+  DBUS_LOCK="interface='org.cinnamon.ScreenSaver',member='ActiveChanged'"
   LOCK_SIGNAL="true"
   UNLOCK_SIGNAL="false"
 elif [ "$XDG_CURRENT_DESKTOP" == "MATE" ] ; then

--- a/pause-on-lock
+++ b/pause-on-lock
@@ -38,7 +38,7 @@ elif [ "$XDG_CURRENT_DESKTOP" == "MATE" ] ; then
   LOCK_SIGNAL="true"
   UNLOCK_SIGNAL="false"
 else
-echo "Error: Unsupported desktop. Supported desktops are Unity, GNOME and Cinnamon."
+echo "Error: Unsupported desktop. Supported desktops are Unity, GNOME, Cinnamon and Mate."
 exit 0
 fi
 dbus-monitor --session "type='signal',$DBUS_LOCK" | \

--- a/pause-on-lock
+++ b/pause-on-lock
@@ -30,6 +30,10 @@ elif [[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]] ; then
   LOCK_SIGNAL="true"
   UNLOCK_SIGNAL="false"
 elif [ "$XDG_CURRENT_DESKTOP" == "X-Cinnamon" ] ; then
+  DBUS_LOCK="interface='org.mate.ScreenSaver',member='ActiveChanged'"
+  LOCK_SIGNAL="true"
+  UNLOCK_SIGNAL="false"
+elif [ "$XDG_CURRENT_DESKTOP" == "MATE" ] ; then
   DBUS_LOCK="interface='org.cinnamon.ScreenSaver',member='ActiveChanged'"
   LOCK_SIGNAL="true"
   UNLOCK_SIGNAL="false"


### PR DESCRIPTION
Added support for Mate DE.
Tested with Ubuntu 18.04.2 LTS and Mate DE 1.20.1.